### PR TITLE
Add live dashboard interface for Discord bot state

### DIFF
--- a/public/dashboard/app.js
+++ b/public/dashboard/app.js
@@ -1,0 +1,425 @@
+const REFRESH_INTERVAL = 5000;
+
+const statusIndicator = document.getElementById('bot-status-indicator');
+const lastUpdatedEl = document.getElementById('last-updated');
+const botUptimeEl = document.getElementById('bot-uptime');
+const botPingEl = document.getElementById('bot-ping');
+const botAvatarEl = document.getElementById('bot-avatar');
+const botNameEl = document.getElementById('bot-name');
+const botIdEl = document.getElementById('bot-id');
+const botReadyEl = document.getElementById('bot-ready');
+const guildListEl = document.getElementById('guild-list');
+const activityLogEl = document.getElementById('activity-log');
+const activityCountEl = document.getElementById('activity-count');
+const mapsContainerEl = document.getElementById('maps-container');
+const mapCountEl = document.getElementById('map-count');
+const datasetContainerEl = document.getElementById('dataset-container');
+const datasetCountEl = document.getElementById('dataset-count');
+const assetContainerEl = document.getElementById('asset-container');
+const commandListEl = document.getElementById('command-list');
+const commandCountEl = document.getElementById('command-count');
+const commandSearchEl = document.getElementById('command-search');
+
+const activityTemplate = document.getElementById('activity-template');
+const commandTemplate = document.getElementById('command-template');
+
+let commandCache = [];
+let pollingHandle;
+
+function start() {
+  fetchAndRender();
+  if (commandSearchEl) {
+    commandSearchEl.addEventListener('input', () => updateCommandList(commandSearchEl.value));
+  }
+}
+
+async function fetchAndRender() {
+  try {
+    const response = await fetch('/dashboard/state', { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`);
+    }
+    const state = await response.json();
+    renderState(state);
+    statusIndicator.classList.add('is-online');
+  } catch (error) {
+    console.error('Failed to fetch dashboard state:', error);
+    statusIndicator.classList.remove('is-online');
+    lastUpdatedEl.textContent = 'Connection lost';
+  } finally {
+    pollingHandle = setTimeout(fetchAndRender, REFRESH_INTERVAL);
+  }
+}
+
+function renderState(state) {
+  if (!state) return;
+  const timestamp = state.generatedAt ? new Date(state.generatedAt) : new Date();
+  lastUpdatedEl.textContent = timestamp.toLocaleTimeString();
+
+  renderBot(state.bot ?? {});
+  renderGuilds(state.guilds ?? []);
+  renderActivity(state.activity ?? []);
+  renderMaps(state.maps ?? {});
+  renderDatasets(state.datasets ?? {});
+  renderCommands(state.commands ?? { entries: [] });
+}
+
+function renderBot(bot) {
+  botUptimeEl.textContent = bot.uptime ?? '—';
+  botPingEl.textContent = bot.ping != null ? `${Math.round(bot.ping)} ms` : '—';
+
+  if (botAvatarEl) {
+    if (bot.avatar) {
+      botAvatarEl.src = bot.avatar;
+    } else {
+      botAvatarEl.removeAttribute('src');
+    }
+  }
+
+  botNameEl.textContent = bot.tag || bot.username || 'Unknown Bot';
+  botIdEl.textContent = bot.id ? `ID: ${bot.id}` : 'ID unavailable';
+  botReadyEl.textContent = bot.ready ? 'Status: Online' : 'Status: Offline';
+}
+
+function renderGuilds(guilds) {
+  guildListEl.innerHTML = '';
+  if (!guilds.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No guilds connected.';
+    guildListEl.appendChild(empty);
+    return;
+  }
+
+  for (const guild of guilds) {
+    const item = document.createElement('li');
+    const name = document.createElement('strong');
+    name.textContent = guild.name || guild.id;
+    const meta = document.createElement('span');
+    meta.textContent = `${guild.memberCount ?? '—'} members`;
+    item.appendChild(name);
+    item.appendChild(meta);
+    guildListEl.appendChild(item);
+  }
+}
+
+function renderActivity(activity) {
+  activityLogEl.innerHTML = '';
+  activityCountEl.textContent = activity.length;
+
+  const fragment = document.createDocumentFragment();
+  const maxEntries = 60;
+
+  for (const entry of activity.slice(0, maxEntries)) {
+    const node = activityTemplate.content.cloneNode(true);
+    const typeEl = node.querySelector('.activity__type');
+    const timeEl = node.querySelector('.activity__time');
+    const bodyEl = node.querySelector('.activity__body');
+
+    typeEl.textContent = formatActivityType(entry.type);
+    timeEl.textContent = entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : '—';
+    bodyEl.appendChild(buildActivityBody(entry));
+
+    fragment.appendChild(node);
+  }
+
+  if (!fragment.childElementCount) {
+    const empty = document.createElement('p');
+    empty.className = 'muted';
+    empty.textContent = 'No activity recorded yet.';
+    activityLogEl.appendChild(empty);
+  } else {
+    activityLogEl.appendChild(fragment);
+  }
+}
+
+function buildActivityBody(entry) {
+  const fragment = document.createDocumentFragment();
+  if (entry.type === 'command' || entry.type === 'command_error') {
+    const commandLine = document.createElement('div');
+    const strong = document.createElement('strong');
+    strong.textContent = `!${entry.command}`;
+    commandLine.appendChild(strong);
+    if (entry.args && entry.args.length) {
+      const argsSpan = document.createElement('span');
+      argsSpan.textContent = ` ${entry.args.join(' ')}`;
+      commandLine.appendChild(argsSpan);
+    }
+    fragment.appendChild(commandLine);
+
+    const context = [];
+    if (entry.user) {
+      const userId = entry.user.tag || entry.user.username || entry.user.id;
+      if (userId) context.push(`👤 ${userId}`);
+    }
+    if (entry.guild) {
+      context.push(`🏠 ${entry.guild.name || entry.guild.id}`);
+    }
+    if (entry.channel) {
+      context.push(`#${entry.channel.name || entry.channel.id}`);
+    }
+    if (context.length) {
+      const meta = document.createElement('div');
+      meta.className = 'muted';
+      meta.textContent = context.join(' • ');
+      fragment.appendChild(meta);
+    }
+    if (entry.error) {
+      const errorLine = document.createElement('div');
+      errorLine.className = 'error-line';
+      errorLine.textContent = `⚠️ ${entry.error.message || entry.error}`;
+      fragment.appendChild(errorLine);
+    }
+  } else {
+    const payload = entry.payload ?? entry;
+    const pre = document.createElement('pre');
+    pre.textContent = stringify(payload);
+    fragment.appendChild(pre);
+  }
+  return fragment;
+}
+
+function formatActivityType(type) {
+  if (!type) return 'EVENT';
+  switch (type) {
+    case 'command':
+      return 'COMMAND';
+    case 'command_error':
+      return 'COMMAND ⚠️';
+    case 'unknownCommand':
+      return 'UNKNOWN CMD';
+    default:
+      return type.replace(/_/g, ' ').toUpperCase();
+  }
+}
+
+function renderMaps(maps) {
+  mapsContainerEl.innerHTML = '';
+  const entries = Object.entries(maps);
+  mapCountEl.textContent = entries.length;
+
+  if (!entries.length) {
+    const empty = document.createElement('p');
+    empty.className = 'muted';
+    empty.textContent = 'No live maps registered.';
+    mapsContainerEl.appendChild(empty);
+    return;
+  }
+
+  for (const [name, info] of entries) {
+    const card = document.createElement('div');
+    card.className = 'map-card';
+    const title = document.createElement('h3');
+    title.textContent = `${formatKey(name)} (${info.size ?? 0})`;
+    card.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'muted';
+    meta.textContent = `Type: ${info.type || 'Unknown'}`;
+    card.appendChild(meta);
+
+    if (info.sample && info.sample.length) {
+      const pre = document.createElement('pre');
+      pre.textContent = stringify(info.sample);
+      card.appendChild(pre);
+    } else {
+      const empty = document.createElement('p');
+      empty.className = 'muted';
+      empty.textContent = 'No active entries yet.';
+      card.appendChild(empty);
+    }
+
+    mapsContainerEl.appendChild(card);
+  }
+}
+
+function renderDatasets(datasets) {
+  datasetContainerEl.innerHTML = '';
+  const entries = Object.entries(datasets);
+  const datasetEntries = [];
+  const assetEntries = [];
+
+  for (const [name, value] of entries) {
+    if (value && typeof value === 'object' && Array.isArray(value.files)) {
+      assetEntries.push([name, value]);
+    } else {
+      datasetEntries.push([name, value]);
+    }
+  }
+
+  datasetCountEl.textContent = datasetEntries.length;
+
+  if (!datasetEntries.length) {
+    const empty = document.createElement('p');
+    empty.className = 'muted';
+    empty.textContent = 'No live datasets available.';
+    datasetContainerEl.appendChild(empty);
+  } else {
+    for (const [name, value] of datasetEntries) {
+      const card = document.createElement('div');
+      card.className = 'dataset-card';
+      const title = document.createElement('h3');
+      title.textContent = formatKey(name);
+      card.appendChild(title);
+      const pre = document.createElement('pre');
+      pre.textContent = stringify(value);
+      card.appendChild(pre);
+      datasetContainerEl.appendChild(card);
+    }
+  }
+
+  renderAssets(assetEntries);
+}
+
+function renderAssets(assetEntries) {
+  assetContainerEl.innerHTML = '';
+  if (!assetEntries.length) {
+    const empty = document.createElement('p');
+    empty.className = 'muted';
+    empty.textContent = 'No asset manifests registered yet.';
+    assetContainerEl.appendChild(empty);
+    return;
+  }
+
+  for (const [name, info] of assetEntries) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'asset-group';
+
+    const title = document.createElement('h3');
+    title.textContent = `${formatKey(name)} (${info.total ?? 0})`;
+    wrapper.appendChild(title);
+
+    const grid = document.createElement('div');
+    grid.className = 'asset-group__grid';
+
+    const files = (info.files || []).slice(0, 24);
+    for (const file of files) {
+      const card = document.createElement('div');
+      card.className = 'asset';
+      if (file.url && /\.(png|jpg|jpeg|gif|webp)$/i.test(file.url)) {
+        const img = document.createElement('img');
+        img.src = file.url;
+        img.alt = file.path;
+        card.appendChild(img);
+      }
+      const pathEl = document.createElement('div');
+      pathEl.className = 'asset__path';
+      pathEl.textContent = file.path;
+      card.appendChild(pathEl);
+      grid.appendChild(card);
+    }
+
+    if (!grid.childElementCount) {
+      const note = document.createElement('p');
+      note.className = 'muted';
+      note.textContent = 'No previewable files found.';
+      wrapper.appendChild(note);
+    } else {
+      wrapper.appendChild(grid);
+    }
+
+    assetContainerEl.appendChild(wrapper);
+  }
+}
+
+function renderCommands(commands) {
+  commandCache = Array.isArray(commands.entries) ? commands.entries : [];
+  commandCountEl.textContent = commandCache.length;
+  updateCommandList(commandSearchEl?.value || '');
+}
+
+function updateCommandList(filterTerm) {
+  const term = (filterTerm || '').trim().toLowerCase();
+  commandListEl.innerHTML = '';
+
+  const filtered = !term
+    ? commandCache
+    : commandCache.filter((entry) =>
+        entry.name.toLowerCase().includes(term) ||
+        (entry.description && entry.description.toLowerCase().includes(term)) ||
+        (entry.aliases || []).some((alias) => alias.toLowerCase().includes(term))
+      );
+
+  if (!filtered.length) {
+    const empty = document.createElement('p');
+    empty.className = 'muted';
+    empty.textContent = 'No commands match your search.';
+    commandListEl.appendChild(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (const entry of filtered) {
+    const node = commandTemplate.content.cloneNode(true);
+    const nameEl = node.querySelector('.command__name');
+    const descriptionEl = node.querySelector('.command__description');
+    const metaEl = node.querySelector('.command__meta');
+    const detailsEl = node.querySelector('.command__details');
+
+    nameEl.textContent = `!${entry.name}`;
+    descriptionEl.textContent = entry.description || 'No description provided yet.';
+
+    metaEl.innerHTML = '';
+    if (entry.category) metaEl.appendChild(createBadge(`Category: ${formatKey(entry.category)}`));
+    if (entry.cooldown) metaEl.appendChild(createBadge(`Cooldown: ${entry.cooldown}`));
+    if (entry.aliases && entry.aliases.length) {
+      metaEl.appendChild(createBadge(`Aliases: ${entry.aliases.join(', ')}`));
+    }
+
+    detailsEl.innerHTML = '';
+    if (entry.usage) {
+      const usage = document.createElement('span');
+      usage.textContent = `Usage: ${entry.usage}`;
+      detailsEl.appendChild(usage);
+    }
+
+    const metaEntries = Object.entries(entry.metadata || {});
+    for (const [key, value] of metaEntries) {
+      const span = document.createElement('span');
+      span.textContent = `${formatKey(key)}: ${formatMetadataValue(value)}`;
+      detailsEl.appendChild(span);
+    }
+
+    fragment.appendChild(node);
+  }
+
+  commandListEl.appendChild(fragment);
+}
+
+function createBadge(text) {
+  const badge = document.createElement('span');
+  badge.className = 'badge';
+  badge.textContent = text;
+  return badge;
+}
+
+function stringify(value) {
+  if (value === null || value === undefined) return String(value);
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (error) {
+    return String(value);
+  }
+}
+
+function formatKey(key) {
+  if (!key) return '';
+  return key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/_/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+function formatMetadataValue(value) {
+  if (Array.isArray(value)) return value.join(', ');
+  if (value && typeof value === 'object') return stringify(value);
+  return String(value);
+}
+
+window.addEventListener('beforeunload', () => {
+  if (pollingHandle) clearTimeout(pollingHandle);
+});
+
+start();

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dreamworld Console Viewer</title>
+    <link rel="stylesheet" href="/dashboard/style.css" />
+  </head>
+  <body>
+    <div class="layout">
+      <header class="hero">
+        <div class="hero__status">
+          <div class="hero__light" id="bot-status-indicator"></div>
+          <div>
+            <h1>Dreamworld Live Control Room</h1>
+            <p class="hero__subtitle">
+              Discord is the console. This dashboard is the TV. Watch every system heartbeat in real time.
+            </p>
+          </div>
+        </div>
+        <div class="hero__meta">
+          <div>
+            <span class="label">Last update</span>
+            <span class="value" id="last-updated">—</span>
+          </div>
+          <div>
+            <span class="label">Uptime</span>
+            <span class="value" id="bot-uptime">—</span>
+          </div>
+          <div>
+            <span class="label">Latency</span>
+            <span class="value" id="bot-ping">—</span>
+          </div>
+        </div>
+      </header>
+
+      <main class="grid">
+        <section class="card card--wide" id="bot-overview">
+          <h2>Bot Overview</h2>
+          <div class="bot-overview__content">
+            <div class="bot-overview__identity">
+              <img id="bot-avatar" alt="Bot avatar" class="bot-overview__avatar" />
+              <div>
+                <h3 id="bot-name">—</h3>
+                <p id="bot-id" class="muted">—</p>
+                <p id="bot-ready" class="muted">Status: —</p>
+              </div>
+            </div>
+            <div class="bot-overview__guilds">
+              <h4>Connected Guilds</h4>
+              <ul id="guild-list" class="list"></ul>
+            </div>
+          </div>
+        </section>
+
+        <section class="card" id="activity-feed">
+          <div class="card__header">
+            <h2>Live Activity</h2>
+            <span class="badge" id="activity-count">0</span>
+          </div>
+          <div class="activity-log" id="activity-log"></div>
+        </section>
+
+        <section class="card card--wide" id="command-directory">
+          <div class="card__header">
+            <h2>Command Directory</h2>
+            <div class="command-search">
+              <input type="text" id="command-search" placeholder="Search command" aria-label="Search commands" />
+              <span class="badge" id="command-count">0</span>
+            </div>
+          </div>
+          <div class="commands" id="command-list"></div>
+        </section>
+
+        <section class="card" id="maps-overview">
+          <div class="card__header">
+            <h2>Feature Maps</h2>
+            <span class="badge" id="map-count">0</span>
+          </div>
+          <div class="maps" id="maps-container"></div>
+        </section>
+
+        <section class="card" id="dataset-overview">
+          <div class="card__header">
+            <h2>Live Data Snapshots</h2>
+            <span class="badge" id="dataset-count">0</span>
+          </div>
+          <div class="datasets" id="dataset-container"></div>
+        </section>
+
+        <section class="card card--wide" id="asset-gallery">
+          <div class="card__header">
+            <h2>Shared Assets</h2>
+          </div>
+          <div class="assets" id="asset-container"></div>
+        </section>
+      </main>
+    </div>
+
+    <template id="activity-template">
+      <article class="activity">
+        <div class="activity__meta">
+          <span class="activity__type"></span>
+          <span class="activity__time"></span>
+        </div>
+        <div class="activity__body"></div>
+      </article>
+    </template>
+
+    <template id="command-template">
+      <article class="command">
+        <header>
+          <h3 class="command__name"></h3>
+          <div class="command__meta"></div>
+        </header>
+        <p class="command__description"></p>
+        <div class="command__details"></div>
+      </article>
+    </template>
+
+    <script src="/dashboard/app.js" type="module"></script>
+  </body>
+</html>

--- a/public/dashboard/style.css
+++ b/public/dashboard/style.css
@@ -1,0 +1,400 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --bg-panel: #161b22;
+  --bg-elevated: #1f2733;
+  --accent: #7f5bff;
+  --accent-soft: rgba(127, 91, 255, 0.2);
+  --muted: #8b949e;
+  --border: rgba(255, 255, 255, 0.04);
+  --success: #2ecc71;
+  --danger: #ff4d6d;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(127, 91, 255, 0.1), transparent 55%), var(--bg);
+  color: #f5f7fb;
+  min-height: 100vh;
+}
+
+.layout {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2.5rem 2rem 4rem;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.hero__status {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.hero__light {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--danger);
+  box-shadow: 0 0 18px rgba(255, 77, 109, 0.65);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.hero__light.is-online {
+  background: var(--success);
+  box-shadow: 0 0 18px rgba(46, 204, 113, 0.65);
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.hero__subtitle {
+  margin: 0.4rem 0 0;
+  color: var(--muted);
+  max-width: 540px;
+}
+
+.hero__meta {
+  display: grid;
+  gap: 0.5rem;
+  min-width: 220px;
+}
+
+.hero__meta .label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.hero__meta .value {
+  font-size: 1.1rem;
+}
+
+.grid {
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.75rem;
+}
+
+.card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.18);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(127, 91, 255, 0.12), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.card:hover::before {
+  opacity: 1;
+}
+
+.card--wide {
+  grid-column: span 2;
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.list li {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.list li span {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.bot-overview__content {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(200px, 1fr);
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.bot-overview__avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  object-fit: cover;
+  background: var(--bg);
+}
+
+.bot-overview__guilds {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.activity-log {
+  display: grid;
+  gap: 1rem;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.activity-log::-webkit-scrollbar {
+  width: 6px;
+}
+
+.activity-log::-webkit-scrollbar-thumb {
+  background: rgba(127, 91, 255, 0.35);
+  border-radius: 999px;
+}
+
+.activity {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.activity__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.activity__type {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.activity__body {
+  font-size: 0.95rem;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.command-search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.command-search input {
+  flex: 1;
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(15, 18, 26, 0.75);
+  color: inherit;
+}
+
+.commands {
+  display: grid;
+  gap: 1rem;
+  max-height: 480px;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.command {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.command header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.command__name {
+  margin: 0;
+}
+
+.command__description {
+  margin: 0;
+  color: var(--muted);
+}
+
+.command__details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.command__details span {
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.maps,
+.datasets {
+  display: grid;
+  gap: 1rem;
+}
+
+.map-card,
+.dataset-card {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.map-card h3,
+.dataset-card h3 {
+  margin: 0 0 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.map-card pre,
+.dataset-card pre {
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 10px;
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.assets {
+  display: grid;
+  gap: 1rem;
+}
+
+.asset-group {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.asset-group__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.asset {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 14px;
+  padding: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.asset img {
+  width: 100%;
+  border-radius: 10px;
+  object-fit: cover;
+  aspect-ratio: 1 / 1;
+}
+
+.asset__path {
+  font-size: 0.75rem;
+  color: var(--muted);
+  word-break: break-all;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.error-line {
+  color: var(--danger);
+  font-size: 0.85rem;
+  margin-top: 0.35rem;
+}
+
+@media (max-width: 960px) {
+  .card--wide {
+    grid-column: span 1;
+  }
+
+  .bot-overview__content {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero__meta {
+    width: 100%;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}

--- a/utils/dashboardState.js
+++ b/utils/dashboardState.js
@@ -1,0 +1,329 @@
+const fs = require('fs');
+const path = require('path');
+
+const MAX_ACTIVITY = 200;
+
+const registeredMaps = new Map();
+const registeredAccessors = new Map();
+const activityLog = [];
+
+function registerMap(name, map) {
+  if (!name) return;
+  registeredMaps.set(name, map);
+}
+
+function registerAccessor(name, getter) {
+  if (!name || typeof getter !== 'function') return;
+  registeredAccessors.set(name, getter);
+}
+
+function recordEvent(type, payload = {}) {
+  const entry = {
+    type,
+    payload: sanitize(payload),
+    timestamp: new Date().toISOString()
+  };
+  activityLog.unshift(entry);
+  if (activityLog.length > MAX_ACTIVITY) {
+    activityLog.length = MAX_ACTIVITY;
+  }
+  return entry;
+}
+
+function recordCommandEvent(details) {
+  if (!details || !details.command) return;
+  const entry = {
+    type: details.error ? 'command_error' : 'command',
+    command: details.command,
+    user: details.user ? sanitize(details.user) : null,
+    guild: details.guild ? sanitize(details.guild) : null,
+    channel: details.channel ? sanitize(details.channel) : null,
+    args: Array.isArray(details.args) ? details.args.slice(0, 25) : [],
+    messageId: details.messageId,
+    error: details.error ? sanitize(details.error) : null,
+    timestamp: new Date().toISOString()
+  };
+  activityLog.unshift(entry);
+  if (activityLog.length > MAX_ACTIVITY) {
+    activityLog.length = MAX_ACTIVITY;
+  }
+  return entry;
+}
+
+function sanitize(value, depth = 0) {
+  if (value === null || value === undefined) return value;
+  if (depth > 3) return '[MaxDepth]';
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof Map) {
+    return {
+      type: 'Map',
+      size: value.size
+    };
+  }
+
+  if (value instanceof Set) {
+    return {
+      type: 'Set',
+      size: value.size,
+      values: Array.from(value).slice(0, 10).map((item) => sanitize(item, depth + 1))
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 25).map((item) => sanitize(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    const output = {};
+    for (const [key, val] of Object.entries(value)) {
+      if (typeof val === 'function' || typeof val === 'symbol') continue;
+      output[key] = sanitize(val, depth + 1);
+    }
+    return output;
+  }
+
+  return value;
+}
+
+function summarizeMap(map) {
+  if (!map) {
+    return { type: 'unknown', size: 0, sample: [] };
+  }
+
+  if (map instanceof Map) {
+    const sample = [];
+    let index = 0;
+    for (const [key, value] of map.entries()) {
+      if (index++ >= 10) break;
+      sample.push({ key, value: sanitize(value) });
+    }
+    return {
+      type: 'Map',
+      size: map.size,
+      sample
+    };
+  }
+
+  if (map instanceof Set) {
+    const values = Array.from(map).slice(0, 10).map((value) => sanitize(value));
+    return {
+      type: 'Set',
+      size: map.size,
+      sample: values
+    };
+  }
+
+  if (Array.isArray(map)) {
+    return {
+      type: 'Array',
+      size: map.length,
+      sample: map.slice(0, 10).map((value) => sanitize(value))
+    };
+  }
+
+  if (typeof map === 'object') {
+    const entries = Object.entries(map).slice(0, 10).map(([key, value]) => ({
+      key,
+      value: sanitize(value)
+    }));
+    return {
+      type: 'Object',
+      size: Object.keys(map).length,
+      sample: entries
+    };
+  }
+
+  return {
+    type: typeof map,
+    size: 0,
+    sample: []
+  };
+}
+
+function formatDuration(ms = 0) {
+  if (!ms || Number.isNaN(ms)) return '0s';
+  const totalSeconds = Math.floor(ms / 1000);
+  const seconds = totalSeconds % 60;
+  const minutes = Math.floor(totalSeconds / 60) % 60;
+  const hours = Math.floor(totalSeconds / 3600) % 24;
+  const days = Math.floor(totalSeconds / 86400);
+  const parts = [];
+  if (days) parts.push(`${days}d`);
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  if (seconds || parts.length === 0) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+function buildCommandSummary(commandsCollection) {
+  const entries = [];
+  if (!commandsCollection || typeof commandsCollection.entries !== 'function') {
+    return { total: 0, entries };
+  }
+
+  for (const [name, config] of commandsCollection.entries()) {
+    const entry = {
+      name,
+      description: null,
+      usage: null,
+      category: null,
+      cooldown: null,
+      aliases: [],
+      metadata: {}
+    };
+
+    if (config) {
+      if (typeof config.description === 'string') entry.description = config.description;
+      else if (typeof config.desc === 'string') entry.description = config.desc;
+      else if (typeof config.details === 'string') entry.description = config.details;
+      else if (config.help && typeof config.help.description === 'string') entry.description = config.help.description;
+
+      if (typeof config.usage === 'string') entry.usage = config.usage;
+      else if (config.help && typeof config.help.usage === 'string') entry.usage = config.help.usage;
+
+      if (typeof config.category === 'string') entry.category = config.category;
+      else if (typeof config.type === 'string') entry.category = config.type;
+
+      if (config.cooldown || config.coolDown) entry.cooldown = config.cooldown || config.coolDown;
+
+      if (Array.isArray(config.aliases)) entry.aliases = config.aliases;
+      else if (typeof config.alias === 'string') entry.aliases = [config.alias];
+
+      const extraKeys = ['permissions', 'requires', 'level', 'tier', 'cost', 'unlock'];
+      for (const key of extraKeys) {
+        if (config[key] !== undefined) {
+          entry.metadata[key] = sanitize(config[key]);
+        }
+      }
+
+      if (config?.name && config.name !== name) {
+        entry.metadata.exportedName = config.name;
+      }
+    }
+
+    entries.push(entry);
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  return {
+    total: entries.length,
+    entries
+  };
+}
+
+function getState(client) {
+  const now = Date.now();
+  const bot = {};
+  if (client && client.user) {
+    bot.id = client.user.id;
+    bot.username = client.user.username;
+    bot.tag = client.user.tag;
+    bot.avatar = client.user.displayAvatarURL?.() || null;
+    bot.ready = client.isReady?.() ?? true;
+    bot.uptimeMs = client.uptime ?? 0;
+    bot.uptime = formatDuration(client.uptime ?? 0);
+    bot.ping = client.ws?.ping ?? null;
+    bot.presence = sanitize(client.user.presence ?? {});
+  } else {
+    bot.ready = false;
+  }
+
+  const guilds = [];
+  if (client?.guilds?.cache) {
+    for (const guild of client.guilds.cache.values()) {
+      guilds.push({
+        id: guild.id,
+        name: guild.name,
+        memberCount: guild.memberCount,
+        description: guild.description ?? null,
+        icon: guild.iconURL?.() || null
+      });
+    }
+    guilds.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  const maps = {};
+  for (const [name, map] of registeredMaps.entries()) {
+    maps[name] = summarizeMap(map);
+  }
+
+  const datasets = {};
+  for (const [name, getter] of registeredAccessors.entries()) {
+    try {
+      datasets[name] = sanitize(getter());
+    } catch (error) {
+      datasets[name] = { error: error.message };
+    }
+  }
+
+  return {
+    generatedAt: now,
+    bot,
+    guilds,
+    commands: buildCommandSummary(client?.commands),
+    maps,
+    datasets,
+    activity: activityLog.slice(0, 100)
+  };
+}
+
+function listStaticFiles(rootDir, publicPrefix = '/') {
+  const results = [];
+  if (!rootDir || !fs.existsSync(rootDir)) return results;
+
+  const stack = [{ dir: rootDir, rel: '' }];
+
+  while (stack.length) {
+    const { dir, rel } = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (error) {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const relativePath = path.join(rel, entry.name);
+      if (entry.isDirectory()) {
+        stack.push({ dir: fullPath, rel: relativePath });
+      } else {
+        results.push({
+          path: relativePath.replace(/\\/g, '/'),
+          url: path.posix.join(publicPrefix, relativePath.replace(/\\/g, '/'))
+        });
+      }
+    }
+  }
+
+  results.sort((a, b) => a.path.localeCompare(b.path));
+  return results;
+}
+
+function registerStaticDirectory(name, rootDir, publicPrefix = '/') {
+  registerAccessor(name, () => {
+    const files = listStaticFiles(rootDir, publicPrefix);
+    return {
+      total: files.length,
+      files: files.slice(0, 100)
+    };
+  });
+}
+
+module.exports = {
+  registerMap,
+  registerAccessor,
+  recordEvent,
+  recordCommandEvent,
+  getState,
+  listStaticFiles,
+  registerStaticDirectory
+};


### PR DESCRIPTION
## Summary
- add a reusable dashboard state module to expose in-memory maps, tracked assets, and recent events
- instrument the bot to feed dashboard telemetry and expose a `/dashboard/state` API plus static assets
- add a dark-themed HTML/CSS/JS dashboard that polls the API for live bot, command, and feature data

## Testing
- not run (bot requires Discord credentials to start)

------
https://chatgpt.com/codex/tasks/task_e_68d7b79be154832da528bf0574831733