### PR TITLE
Add dedicated slash command for Streetwalk activity

### DIFF
--- a/commands/dealer_Slash.js
+++ b/commands/dealer_Slash.js
@@ -1,42 +1,14 @@
 // commands/dealer.js
-const {
-  SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, PermissionFlagsBits
-} = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('dealer')
-    .setDescription('Launch the Dreamworld Typing Game as a Discord activity'),
+    .setDescription('Provides information about the dealer tools.'),
   async execute(interaction) {
-    const voice = interaction.member?.voice?.channel;
-    if (!voice) {
-      return interaction.reply({ content: '👋 Join a voice channel first, then run /dealer.', ephemeral: true });
-    }
-
-    // Needs Create Invite on that voice channel
-    try {
-      const invite = await voice.createInvite({
-        targetApplication: process.env.ACTIVITY_APP_ID, // your Discord App (Embedded App) ID
-        targetType: 2,                                   // 2 = Embedded Application
-        maxAge: 86400,
-        maxUses: 0
-      });
-
-      const row = new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-          .setLabel('Open Dreamworld Game')
-          .setStyle(ButtonStyle.Link)
-          .setURL(`https://discord.com/invite/${invite.code}`)
-      );
-
-      return interaction.reply({
-        content: `🎮 Click to launch the game in **${voice.name}**`,
-        components: [row],
-        ephemeral: true
-      });
-    } catch (err) {
-      console.error('Activity invite error:', err);
-      return interaction.reply({ content: '❌ Unable to create activity invite. Check bot permissions.', ephemeral: true });
-    }
+    return interaction.reply({
+      content: '🛠️ Dealer tools are available with the legacy prefix command. Use **/streetwalk** to launch the embedded game.',
+      ephemeral: true
+    });
   }
 };

--- a/commands/streetwalk_Slash.js
+++ b/commands/streetwalk_Slash.js
@@ -1,0 +1,38 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('streetwalk')
+    .setDescription('Launch the Streetwalk web game as a Discord activity.'),
+  async execute(interaction) {
+    const voice = interaction.member?.voice?.channel;
+    if (!voice) {
+      return interaction.reply({ content: '👋 Join a voice channel first, then run /streetwalk.', ephemeral: true });
+    }
+
+    try {
+      const invite = await voice.createInvite({
+        targetApplication: process.env.ACTIVITY_APP_ID,
+        targetType: 2,
+        maxAge: 86400,
+        maxUses: 0
+      });
+
+      const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+          .setLabel('Open Streetwalk Game')
+          .setStyle(ButtonStyle.Link)
+          .setURL(`https://discord.com/invite/${invite.code}`)
+      );
+
+      return interaction.reply({
+        content: `🎮 Click to launch the game in **${voice.name}**`,
+        components: [row],
+        ephemeral: true
+      });
+    } catch (err) {
+      console.error('Activity invite error:', err);
+      return interaction.reply({ content: '❌ Unable to create activity invite. Check bot permissions.', ephemeral: true });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- remove the embedded activity launch flow from `/dealer`
- add a new `/streetwalk` slash command that opens the Streetwalk Activity invite

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d860e4a5d8832da57f7bfb6d9f4fa1