### PR TITLE
Fix Street Walk slash command and wire slash command handling

### DIFF
--- a/commands/dealer_Slash.js
+++ b/commands/dealer_Slash.js
@@ -1,6 +1,10 @@
 // commands/deal.js
 const {
-  SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle
+  SlashCommandBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  PermissionFlagsBits
 } = require('discord.js');
 
 module.exports = {
@@ -15,9 +19,25 @@ module.exports = {
 
     // Needs Create Invite on that voice channel
     try {
-      const invite = await voice.createInvite({
-        targetApplication: process.env.ACTIVITY_APP_ID, // your Discord App (Embedded App) ID
-        targetType: 2,                                   // 2 = Embedded Application
+      const applicationId = process.env.STREETWALK_APP_ID || process.env.ACTIVITY_APP_ID;
+      if (!applicationId) {
+        return interaction.reply({
+          content: '⚙️ Street Walk activity is not configured. Set STREETWALK_APP_ID (or ACTIVITY_APP_ID) and try again.',
+          ephemeral: true
+        });
+      }
+
+      const permissions = interaction.guild.members.me?.permissionsIn(voice);
+      if (permissions && !permissions.has(PermissionFlagsBits.CreateInstantInvite)) {
+        return interaction.reply({
+          content: '❌ I need the **Create Invite** permission in this voice channel to launch Street Walk.',
+          ephemeral: true
+        });
+      }
+
+      const invite = await interaction.guild.invites.create(voice.id, {
+        targetApplication: applicationId,
+        targetType: 2,
         maxAge: 86400,
         maxUses: 0
       });

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ process.on('uncaughtException', err => console.error('❌ Uncaught Exception:', 
 const { Client, GatewayIntentBits, Collection, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, } = require('discord.js');
 const mongoose = require('./utils/localMongoose');
 const express = require('express'); // ✅ <-- ADD THIS LINE
+const fs = require('fs');
 const stealCooldowns = new Map(); // userId → timestamp
 const wantedMap = new Map(); // userId -> { fails: Number, watched: Boolean }
 const hideoutMap = new Map(); // userId → timestamp when hideout expires
@@ -532,6 +533,22 @@ const client = new Client({
 });
 
 client.commands = new Collection(); // ✅ ADD THIS LINE
+client.slashCommands = new Collection();
+
+const slashCommandFiles = fs
+  .readdirSync(path.join(__dirname, 'commands'))
+  .filter(file => file.endsWith('_Slash.js'));
+
+for (const file of slashCommandFiles) {
+  try {
+    const commandModule = require(path.join(__dirname, 'commands', file));
+    if (commandModule?.data?.name && typeof commandModule.execute === 'function') {
+      client.slashCommands.set(commandModule.data.name, commandModule);
+    }
+  } catch (err) {
+    console.error(`❌ Failed to load slash command from ${file}:`, err);
+  }
+}
 
 
 
@@ -3508,8 +3525,30 @@ client.on('messageCreate', async (message) => {
 });
 
 client.on('interactionCreate', async interaction => {
-  
+
   try {
+    if (interaction.isChatInputCommand()) {
+      const slashCommand = interaction.client.slashCommands?.get(interaction.commandName);
+      if (!slashCommand) {
+        if (!interaction.replied && !interaction.deferred) {
+          await interaction.reply({ content: '❌ That command is not available.', ephemeral: true }).catch(() => {});
+        }
+        return;
+      }
+
+      try {
+        await slashCommand.execute(interaction);
+      } catch (commandError) {
+        console.error(`❌ Slash command ${interaction.commandName} failed:`, commandError);
+        if (interaction.deferred || interaction.replied) {
+          await interaction.editReply({ content: '❌ Something went wrong running that command.' }).catch(() => {});
+        } else {
+          await interaction.reply({ content: '❌ Something went wrong running that command.', ephemeral: true }).catch(() => {});
+        }
+      }
+      return;
+    }
+
     if (!interaction.isButton() && !interaction.isStringSelectMenu()) return;
 
     const { customId, user, message } = interaction;


### PR DESCRIPTION
## Summary
- load slash command modules during client startup so chat input interactions are routed through the bot
- harden the /deal Street Walk launcher with configuration and permission checks before creating the embedded app invite

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8794598b0832d8d153fb2444090ab