### PR TITLE
Fix duplicate fs import to restore bot startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,8 +296,6 @@ turfZones.set("Warehouse", { owner: "bounty", lastRaid: 0 });
 
 require('dotenv').config();
 
-const fs = require('fs');
-
 
 
 // Helper: Convert XP to Level


### PR DESCRIPTION
## Summary
- remove the duplicate `fs` import in `index.js` to prevent the SyntaxError thrown during startup

## Testing
- npm run lint *(fails: missing script)*
- npm test *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68d87e0ed498832d848c1cfec5102274