### PR TITLE
Enable voice state intent for Streetwalk command

### DIFF
--- a/index.js
+++ b/index.js
@@ -537,7 +537,8 @@ const client = new Client({
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.GuildMembers,
-    GatewayIntentBits.MessageContent
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.GuildVoiceStates
   ]
 });
 


### PR DESCRIPTION
## Summary
- add the GuildVoiceStates intent to the Discord client so slash commands can detect a member's current voice channel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d894720c18832d9b7c9740d5c01cc8