### PR TITLE
Improve Street Walk invite error handling and quiet mule logging

### DIFF
--- a/events/npc/npcMules.js
+++ b/events/npc/npcMules.js
@@ -55,7 +55,9 @@ async function spawnMule(client, user, guildId) {
   try {
     const profile = await Inventory.findOne({ userId: user.id, guildId });
     if (!profile || !profile.inventory) {
-      console.log(`[MULE SPAWN] No profile or inventory found.`);
+      if (process.env.DEBUG_MULE_SPAWN === 'true') {
+        console.debug(`[MULE SPAWN] No profile or inventory found.`);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- downgrade expected Street Walk invite failures to warnings and provide clearer fallback errors
- guard the Street Walk error reply to include permission-specific guidance when applicable
- silence the noisy "No profile or inventory" mule spawn log unless explicitly enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ac6463d8832daa6c3dd69a6b6f45