### PR TITLE
Remove CSP meta tags when proxying Streetwalk activity

### DIFF
--- a/server/activity/streetwalkProxy.js
+++ b/server/activity/streetwalkProxy.js
@@ -21,6 +21,16 @@ function rewriteStreetwalkHtml(html, proxyPrefix) {
   const prefix = proxyPrefix.endsWith('/') ? proxyPrefix.slice(0, -1) : proxyPrefix;
   const $ = cheerio.load(html, { decodeEntities: false });
 
+  const cspSelectors = [
+    'meta[http-equiv="Content-Security-Policy" i]',
+    'meta[http-equiv="X-Content-Security-Policy" i]',
+    'meta[http-equiv="Content-Security-Policy-Report-Only" i]'
+  ];
+
+  cspSelectors.forEach(selector => {
+    $(selector).remove();
+  });
+
   const rewriteUrl = value => {
     if (!value || typeof value !== 'string') {
       return value;


### PR DESCRIPTION
## Summary
- remove CSP-related meta tags from the proxied Streetwalk HTML so the injected handshake script can execute inside the Discord iframe

## Testing
- not run (explain why)

------
https://chatgpt.com/codex/tasks/task_e_68d8f4f24d5c832da79c84dd35ba24d2