### PR TITLE
Improve streetwalk embed load handling

### DIFF
--- a/public/activity/index.html
+++ b/public/activity/index.html
@@ -228,7 +228,17 @@
         }
       };
 
-      const loadTimeout = setTimeout(() => settleState(false), 12000);
+      const loadTimeout = setTimeout(() => settleState(false), 20000);
+
+      frame?.addEventListener('load', () => {
+        clearTimeout(loadTimeout);
+        settleState(true);
+      });
+
+      frame?.addEventListener('error', () => {
+        clearTimeout(loadTimeout);
+        settleState(false);
+      });
 
       window.addEventListener('message', (event) => {
         const payload = event?.data;


### PR DESCRIPTION
## Summary
- extend the Streetwalk iframe timeout and hook into load/error events to avoid premature fallback messaging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8fa712494832dbdcee98467fb6585