### PR TITLE
Fix Streetwalk iframe URL resolution

### DIFF
--- a/public/activity/index.html
+++ b/public/activity/index.html
@@ -206,7 +206,8 @@
       const loadingOverlay = document.getElementById('loading-overlay');
       const fallbackOverlay = document.getElementById('fallback-overlay');
 
-      frame.src = GAME_URL;
+      const resolvedGameUrl = new URL(GAME_URL, window.location.origin).toString();
+      frame.src = resolvedGameUrl;
 
       openExternalButton?.addEventListener('click', () => {
         window.open(EXTERNAL_URL, '_blank', 'noopener');


### PR DESCRIPTION
## Summary
- resolve the Streetwalk iframe source URL against the current origin so it always loads the proxied activity path

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8fd973a10832d902af8e793c9bb7d