### PR TITLE
Add channel picker to manual broadcast dashboard

### DIFF
--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -41,6 +41,12 @@
             <p class="broadcast-status" id="broadcast-status" aria-live="polite"></p>
           </div>
           <form id="broadcast-form" class="broadcast-form">
+            <div class="broadcast-channel-control">
+              <label for="broadcast-channel" class="muted">Choose a channel</label>
+              <select id="broadcast-channel" name="channel" aria-label="Select Discord channel" required>
+                <option value="" disabled selected>Loading channels…</option>
+              </select>
+            </div>
             <label for="broadcast-message" class="muted">Send a message to the Discord channel</label>
             <textarea
               id="broadcast-message"

--- a/public/dashboard/style.css
+++ b/public/dashboard/style.css
@@ -134,6 +134,35 @@ body {
   gap: 1rem;
 }
 
+.broadcast-channel-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.broadcast-form select {
+  appearance: none;
+  padding: 0.65rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1.4;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.broadcast-form select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(127, 91, 255, 0.25);
+}
+
+.broadcast-form select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .broadcast-form textarea {
   resize: vertical;
   min-height: 120px;


### PR DESCRIPTION
## Summary
- expose available text channels to the dashboard state so the UI can target them safely
- add a dropdown to the manual broadcast form and persist the operator's preferred channel choice
- validate channel permissions on the server before sending and keep the form responsive while posting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db08147f1c832da7ac72c92d0da9b9