### PR TITLE
Fix steal command payouts for lower-level players

### DIFF
--- a/index.js
+++ b/index.js
@@ -5827,11 +5827,13 @@ client.commands.set('steal', {
     const embed = new EmbedBuilder().setTimestamp();
 
     if (success) {
-let stealPercent = 0.1 + Math.min(lvlDiff * 0.02, 0.9);
-let currentBal = await getBalance(target.id, guildId); // ⏱️ Re-fetch live balance
-let cash = Math.min(Math.floor(targetBal * stealPercent), currentBal); // 🛡️ Clamp
+      let stealPercent = 0.1 + Math.min(lvlDiff * 0.02, 0.9);
+      stealPercent = Math.max(0.05, stealPercent); // 🔒 Prevent negative or zero payouts
+      const currentBal = await getBalance(target.id, guildId); // ⏱️ Re-fetch live balance
+      const rawPayout = Math.floor(targetBal * stealPercent);
+      let cash = Math.max(0, Math.min(rawPayout, currentBal)); // 🛡️ Clamp to available cash
 
-console.log(`[STEAL DEBUG] Calculated payout: $${cash}, Live balance: $${currentBal}`);
+      console.log(`[STEAL DEBUG] Calculated payout: $${cash}, Live balance: $${currentBal}`);
 
 
       if (targetInv.has('vest')) {


### PR DESCRIPTION
## Summary
- clamp the steal payout percentage so it never drops below a positive value
- ensure the calculated payout is never negative before cash is transferred

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db0f334ec8832daa61c2bd09e59644